### PR TITLE
Revert "Use symbolic links instead of locale npm modules for /module folder."

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
     "start": "./node_modules/nodemon/bin/nodemon.js app.js",
     "login": "./node_modules/nodemon/bin/nodemon.js app.js login",
     "webpackDevServer": "webpack-dev-server --colors --progress --inline",
-    "test": "./node_modules/mocha/bin/mocha tests/",
-    "prepare": "mkdir -p node_modules && cd node_modules && ln -s ../modules/* ./"
+    "test": "./node_modules/mocha/bin/mocha tests/"
   },
   "dependencies": {
     "bcrypt-nodejs": "0.0.3",
@@ -29,7 +28,11 @@
     "pretty-logger": "^0.1.2",
     "pug": "^2.0.0-beta6",
     "serve-favicon": "^2.3.0",
-    "winston": "^2.0.0"
+    "winston": "^2.0.0",
+    "wouso-foundation": "file:./modules/wouso-foundation",
+    "wouso-qotd": "file:./modules/wouso-qotd",
+    "wouso-quest": "file:./modules/wouso-quest",
+    "wouso-social-login": "file:./modules/wouso-social-login"
   },
   "engines": {
     "node": "4.0.x",


### PR DESCRIPTION
Reverts mariuscoto/wouso-new#51
It breaks Heroku deployment.